### PR TITLE
Hide email address from website to reduce spam

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,6 @@ const jsonLd = {
   name: resumeData.name,
   jobTitle: resumeData.title,
   url: "https://ppanayotov.com",
-  email: resumeData.contact.email,
   telephone: resumeData.contact.phone,
   address: {
     "@type": "PostalAddress",

--- a/src/components/sidebar/ContactInfo.tsx
+++ b/src/components/sidebar/ContactInfo.tsx
@@ -1,6 +1,5 @@
 import type { ContactInfo as ContactInfoType } from "@/data/types";
 import {
-  MailIcon,
   PhoneIcon,
   MapPinIcon,
   GlobeIcon,
@@ -14,12 +13,6 @@ interface ContactInfoProps {
 export function ContactInfo({ contact }: ContactInfoProps) {
   return (
     <address className="not-italic space-y-2.5 px-6 pb-6 text-sm text-body-text">
-      <div className="flex items-center gap-3">
-        <MailIcon />
-        <a href={`mailto:${contact.email}`} className="hover:underline">
-          {contact.email}
-        </a>
-      </div>
       <div className="flex items-center gap-3">
         <PhoneIcon />
         <a href={`tel:${contact.phone.replace(/\s/g, "")}`} className="hover:underline">

--- a/src/data/resume-data.ts
+++ b/src/data/resume-data.ts
@@ -5,7 +5,6 @@ export const resumeData: ResumeData = {
   title: "Software Engineering Manager",
 
   contact: {
-    email: "preslav.panayotov@gmail.com",
     phone: "+359 883 41 44 99",
     location: "Bulgaria, Sofia",
     website: "https://www.ppanayotov.com/",

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,5 +1,4 @@
 export interface ContactInfo {
-  email: string;
   phone: string;
   location: string;
   website: string;


### PR DESCRIPTION
## Summary
- Remove email row (and its icon import) from the sidebar `ContactInfo` component
- Drop the `email` field from the JSON-LD structured data in `page.tsx` so crawlers can't pick it up
- Strip `email` from `resume-data.ts` and its `ContactInfo` type so it no longer ships in the client bundle

LinkedIn remains as the public contact channel.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Visual check that the sidebar still renders correctly without the email row
- [ ] View page source on the deployed site and confirm the email no longer appears anywhere

---
_Generated by [Claude Code](https://claude.ai/code/session_011agAHtgctCfjZjWMnUQLou)_